### PR TITLE
fix url

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -21,7 +21,7 @@
     "bin/tr2draig"
   ],
   "resources": [],
-  "source-url": "https://github.com/finanalyst/L10N-CY.git",
+  "source-url": "https://github.com/finanalyst/rakuast-L10N-CY.git",
   "tags": [
     "LOCALIZATION",
     "WELSH",


### PR DESCRIPTION
the link on raku.land is broken

it is taken from the url field in META6.json

you will need to fez upload again of course